### PR TITLE
Add mod function

### DIFF
--- a/prototypes/mod/Makefile
+++ b/prototypes/mod/Makefile
@@ -1,0 +1,12 @@
+All: main
+LIB=libMod.o
+CC=gcc
+
+main: main.o $(LIB)
+	$(CC) $@.o $(LIB) -g -o $@
+
+.s.o:
+	$(CC) $(@:.o=.s) -g -c -o $@
+
+clean:
+	rm -f *.o main

--- a/prototypes/mod/libMod.s
+++ b/prototypes/mod/libMod.s
@@ -19,7 +19,7 @@
 # Pseudo Code: 
 #   void int mod(int x, int y) {
 #       int quotient = x / y;
-#       int product = x * y;
+#       int product = quotient * y;
 #       int remainder = x - product;
 #
 #       // Fix for negative remainder
@@ -38,7 +38,7 @@ mod:
     STR r4, [sp, #4]
     STR r5, [sp, #8]
     STR r6, [sp, #12]
-    STR r7, [sp, #20]
+    STR r7, [sp, #16]
 
     # Copy passed arguments into r4 and r5
     MOV r4, r0 @ r4 <- dividend
@@ -50,8 +50,8 @@ mod:
     # Store result of divsion function
     MOV r6, r0 @ r6 <- r0 (result)
 
-    # Get the product of the dividend and divisor
-    MUL r7, r4, r5
+    # Get the product of the quotient and divisor
+    MUL r7, r6, r5
 
     # Subtract the product from the dividend to get the remainder
     SUB r0, r4, r7
@@ -65,7 +65,7 @@ mod:
     LDR r4, [sp, #4]
     LDR r5, [sp, #8]
     LDR r6, [sp, #12]
-    LDR r7, [sp, #20]
+    LDR r7, [sp, #16]
     ADD sp, sp, #20
     MOV pc, lr
 # END mod

--- a/prototypes/mod/libMod.s
+++ b/prototypes/mod/libMod.s
@@ -16,17 +16,25 @@
 # Outputs:
 #   r0 - The remainder from dividing r0 / r1
 #
-# Pseudo Code: 
-#   void int mod(int x, int y) {
+
+# Function: mod
+# Purpose: To compute the non-negative remainder of two signed integers.
+#
+# Input:
+#   r0 - Dividend (numerator)
+#   r1 - Divisor  (denominator)
+#
+# Output:
+#   r0 - The non-negative remainder (r0 mod r1)
+#
+# Pseudo Code:
+#   int mod(int x, int y) {
 #       int quotient = x / y;
 #       int product = quotient * y;
 #       int remainder = x - product;
-#
-#       // Fix for negative remainder
-#       if (remainder < 0){
+#       if (remainder < 0) {
 #           remainder = remainder + y;
 #       }
-#
 #       return remainder;
 #   }
 .text

--- a/prototypes/mod/libMod.s
+++ b/prototypes/mod/libMod.s
@@ -1,0 +1,72 @@
+#
+# Program Name: libMod.s
+# Author: Alfredo Ormeno Zuniga
+# Date: 7/25/2025
+# Purpose:
+#   This file contains utility function for performing the mod operator.
+#   These functions are intended to be called from a main driver program.
+#
+# Functions:
+#   - mod:   Computes the remainder of help her
+#
+# Inputs:
+#   r0 - the dividend
+#   r1 - the divisor
+#
+# Outputs:
+#   r0 - The remainder from dividing r0 / r1
+#
+# Pseudo Code: 
+#   void int mod(int x, int y) {
+#       int quotient = x / y;
+#       int product = x * y;
+#       int remainder = x - product;
+#
+#       // Fix for negative remainder
+#       if (remainder < 0){
+#           remainder = remainder + y;
+#       }
+#
+#       return remainder;
+#   }
+.text
+.global mod
+mod:
+    # Push the stack
+    SUB sp, sp, #20
+    STR lr, [sp, #0]
+    STR r4, [sp, #4]
+    STR r5, [sp, #8]
+    STR r6, [sp, #12]
+    STR r7, [sp, #20]
+
+    # Copy passed arguments into r4 and r5
+    MOV r4, r0 @ r4 <- dividend
+    MOV r5, r1 @ r5 <- divisor
+
+    # Perform division (r0 - dividend, r1 - divisor)
+    BL __aeabi_idiv @ r0 <- r0 / r1
+
+    # Store result of divsion function
+    MOV r6, r0 @ r6 <- r0 (result)
+
+    # Get the product of the dividend and divisor
+    MUL r7, r4, r5
+
+    # Subtract the product from the dividend to get the remainder
+    SUB r0, r4, r7
+
+    # Fix for negative remainder
+    CMP r0, #0 @ if remainder <0
+    ADDLT r0, r0, r5 @ then add divisor
+
+    # Pop the stack
+    LDR lr, [sp, #0]
+    LDR r4, [sp, #4]
+    LDR r5, [sp, #8]
+    LDR r6, [sp, #12]
+    LDR r7, [sp, #20]
+    ADD sp, sp, #20
+    MOV pc, lr
+# END mod
+

--- a/prototypes/mod/main.s
+++ b/prototypes/mod/main.s
@@ -1,0 +1,76 @@
+#
+# Program Name: main.s
+# Author: Alfredo Ormeno Zuniga
+# Date: 7/25/2025
+# Purpose:
+#   This is the main driver program to test the mod function defined in libMod.s.
+#   It prompts the user to enter a dividend and a divisor, calls the mod function 
+#   to compute the remainder, and prints the result to the console.
+#
+# Dependencies:
+#   - Requires linking with libMod.s for the `mod` function.
+#   - Uses C library functions: printf, scanf
+#
+# Inputs:
+#   - User provides two integers via console input:
+#     * Dividend (numerator)
+#     * Divisor  (denominator)
+#
+# Outputs:
+#   - Prints the result of dividend mod divisor to the console.
+#
+# Example Flow:
+#   Enter dividend (x): -7
+#   Enter divisor (y): 3
+#   Result: 2
+#
+.global main
+.text
+main:
+    @ Push the stack
+    SUB sp, sp, #4
+    STR lr, [sp, #0]
+
+    @ Prompt for dividend
+    LDR r0, =prompt1
+    BL printf
+
+    LDR r0, =formatInt
+    LDR r1, =dividend
+    BL scanf
+
+    @ Prompt for divisor
+    LDR r0, =prompt2
+    BL printf
+
+    LDR r0, =formatInt
+    LDR r1, =divisor
+    BL scanf
+
+    @ Load inputs into r0 and r1
+    LDR r0, =dividend
+    LDR r0, [r0]        @ r0 = dividend
+    LDR r1, =divisor
+    LDR r1, [r1]        @ r1 = divisor
+
+    @ Call mod function
+    BL mod              @ r0 = mod(r0, r1)
+
+    @ Print result
+    LDR r1, =resultMsg
+    MOV r1, r0          @ move result into r1
+    LDR r0, =resultMsg
+    BL printf
+
+    # Pop the stack
+    LDR lr, [sp, #0]
+    ADD sp, sp, #4
+    MOV pc, lr
+
+.data
+    dividend: .word 0
+    divisor:  .word 0
+    prompt1:   .asciz "Enter dividend (x): "
+    prompt2:   .asciz "Enter divisor (y): "
+    formatInt: .asciz "%d"
+    resultMsg: .asciz "Result: %d\n"


### PR DESCRIPTION
### Summary
This pull request introduces the `mod` function, which computes the non-negative remainder of two signed integers. It uses subtraction-based logic and ensures the result is always within the range [0, divisor).

### Details
- Implements `mod(int x, int y)` using the identity:
  remainder = x - (x / y) * y
- Handles negative remainders by adding the divisor when needed
- Written in ARM Assembly and placed in libMod.s
- Includes full function header and documentation

### Example
- `mod(7, 3)` → 1
- `mod(-7, 3)` → 2